### PR TITLE
Add Polymer 2 compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,10 +20,10 @@
     "/test/"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.3.0"
+    "polymer": "Polymer/polymer#1 - 2"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "web-component-tester": "^4.0.0"
+    "iron-component-page": "PolymerElements/iron-component-page#^2.0.0",
+    "web-component-tester": "^6.0.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <title>clipboard-input Demo</title>
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="../clipboard-input.html">
   </head>
   <body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </head>
   <body>
 
+    <dom-bind>
     <template is="dom-bind">
       <p>An example of <code>&lt;clipboard-input&gt;</code>:</p>
       <p>
@@ -29,6 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <clipboard-input id='el' value='[[copyVal]]' copy-text='Copy' copied-text='Copied' style='width: 100%;'></clipboard-input>
       </div>
     </template>
+    </dom-bind>
 
     <script>
       document.querySelector("template[is='dom-bind']").copyVal = 'Default Test Value';


### PR DESCRIPTION
Update dependencies for Polymer 2.
Wrap `template` in `dom-bind` for Polymer 2 support.

Fixes #5.